### PR TITLE
gemini cli doesnt support type attribute

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "mcpServers": {
     "postman": {
-            "type": "stdio",
             "command": "npx",
             "args": [
                 "@postman/postman-mcp-server@latest"


### PR DESCRIPTION
 Gemini CLI only supports command-based servers so it defaults to stdio and rejects type attribute